### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -25,9 +27,9 @@ jobs:
             output
 
       - name: Set up Node toolchain
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v2
@@ -49,3 +51,6 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 !.eslintrc.json
 
 output

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#17 by @thomashoneyman)
 
 ## [v4.0.0](https://github.com/purescript-contrib/purescript-unsafe-reference/releases/tag/v4.0.0) - 2021-02-26
 

--- a/src/Unsafe/Reference.purs
+++ b/src/Unsafe/Reference.purs
@@ -1,8 +1,8 @@
 module Unsafe.Reference
   ( unsafeRefEq
   , reallyUnsafeRefEq
-  , UnsafeRefEq (..)
-  , UnsafeRefEqFallback (..)
+  , UnsafeRefEq(..)
+  , UnsafeRefEqFallback(..)
   ) where
 
 import Prelude
@@ -27,6 +27,6 @@ newtype UnsafeRefEqFallback a = UnsafeRefEqFallback a
 instance eqUnsafeRefEqFallback ::
   Eq a =>
   Eq (UnsafeRefEqFallback a) where
-    eq (UnsafeRefEqFallback l) (UnsafeRefEqFallback r) =
-      unsafeRefEq l r || l == r
+  eq (UnsafeRefEqFallback l) (UnsafeRefEqFallback r) =
+    unsafeRefEq l r || l == r
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -24,11 +24,11 @@ derive instance eqX :: Eq X
 main :: Effect Unit
 main = do
   let
-    foo1 = Foo  "foo"
-    foo2 = Foo  "foo"
+    foo1 = Foo "foo"
+    foo2 = Foo "foo"
     foo3 = Foo' "foo"
     foo4 = Foo' "foo"
-    bar1 = Bar  "foo"
+    bar1 = Bar "foo"
     bar2 = Bar' "foo"
 
   assert (unsafeRefEq foo1 foo1) "unsafeRefEq data"


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
